### PR TITLE
fix: Can not returns errors object.

### DIFF
--- a/lib/resolvers/task_resolver.ex
+++ b/lib/resolvers/task_resolver.ex
@@ -19,7 +19,10 @@ defmodule Gannbaruzoi.TaskResolver do
 
     case Repo.insert(changeset) do
       {:ok, task} -> {:ok, %{task: task}}
-      {:error, changeset} -> {:error, changeset.errors}
+      {:error, changeset} ->
+        errors = Enum.map(changeset.errors,
+                          fn {k, {v, _}} -> %{message: "#{k} #{v}"} end)
+        {:error, errors}
     end
   end
 
@@ -28,7 +31,10 @@ defmodule Gannbaruzoi.TaskResolver do
 
     case Repo.update(changeset) do
       {:ok, task} -> {:ok, %{task: task}}
-      {:error, changeset} -> {:error, changeset.errors}
+      {:error, changeset} ->
+        errors = Enum.map(changeset.errors,
+                          fn {k, {v, _}} -> %{message: "#{k} #{v}"} end)
+        {:error, errors}
     end
   end
 

--- a/test/graphs/tasks_test.exs
+++ b/test/graphs/tasks_test.exs
@@ -147,14 +147,17 @@ defmodule Gannbaruzoi.TasksTest do
          %{document: document, user: user} do
       variables = %{
         "clientMutationId" => "1",
-        "description" => nil
+        "description" => "",
+        "estimatedSize" => 5
       }
       result = execute_query(document,
                              variables: variables,
                              context: %{current_user: user})
 
-      assert {:ok, %{errors: errors}} = result
-      assert 1 == length(errors)
+      assert {:ok, %{errors: [%{
+        locations: [%{column: 0, line: 7}],
+        message: "In field \"createTask\": description can't be blank"
+      }]}} = result
     end
   end
 
@@ -207,18 +210,21 @@ defmodule Gannbaruzoi.TasksTest do
     @tag login_as: "user@email.com"
     test "fails to update task with invalid args",
          %{document: document, user: user} do
+      task = insert!(:task, %{user: user})
       variables = %{
         "clientMutationId" => "1",
-        "id" => nil,
-        "description" => "Updated Todo",
+        "id" => task.id,
+        "description" => "",
         "estimatedSize" => 2
       }
       result = execute_query(document,
                              variables: variables,
                              context: %{current_user: user})
 
-      assert {:ok, %{errors: errors}} = result
-      assert 1 == length(errors)
+      assert {:ok, %{errors: [%{
+        locations: [%{column: 0, line: 7}],
+        message: "In field \"updateTask\": description can't be blank"
+      }]}} = result
     end
   end
 


### PR DESCRIPTION
Full message was:

```
     ** (Absinthe.ExecutionError) Invalid value returned from resolver.

     Resolving field:

         updateTask

     Defined at:

         /Users/marocchino/Documents/gannbaruzoi/lib/schema.ex:58

     Resolving on:

         %{}

     Got value:

         {:error, [description: {"can't be blank", [validation: :required]}]}

     ...

     You're returning an :error tuple, but did you forget to include a `:message`
     key in every custom error (map or keyword list)?

     ...

     The result must be one of the following...

     ## For a data result

     `{:ok, any}` result will do.

     ### Examples:

     A simple integer result:

         {:ok, 1}

     Something more complex:

         {:ok, %Model.Thing{some: %{complex: :data}}}

     ## For an error result

     One or more errors for a field can be returned in a single `{:error, error_value}` tuple.

     `error_value` can be:
     - A simple error message string.
     - A map containing `:message` key, plus any additional serializable metadata.
     - A keyword list containing a `:message` key, plus any additional serializable metadata.
     - A list containing multiple of any/all of these.

     ### Examples

     A simple error message:

         {:error, "Something bad happened"}

     Multiple error messages:

         {:error, ["Something bad", "Even worse"]

     Single custom errors (note the required `:message` keys):

         {:error, message: "Unknown user", code: 21}
         {:error, %{message: "A database error occurred", details: format_db_error(some_value)}}

     Three errors of mixed types:

         {:error, ["Simple message", [message: "A keyword list error", code: 1], %{message: "A map error"}]}

     ## To activate a plugin

     `{:plugin, NameOfPluginModule, term}` to activate a plugin.

     See `Absinthe.Resolution.Plugin` for more information.

     code: result = execute_query(document,
     stacktrace:
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:229: Absinthe.Phase.Document.Execution.Resolution.raise_result_error!/4
       (elixir) lib/enum.ex:1826: Enum."-reduce/3-lists^foldl/2-0-"/3
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:263: Absinthe.Phase.Document.Execution.Resolution.build_error_result/6
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:186: Absinthe.Phase.Document.Execution.Resolution.do_resolve_fields/5
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:133: Absinthe.Phase.Document.Execution.Resolution.walk_result/5
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:101: Absinthe.Phase.Document.Execution.Resolution.perform_resolution/3
       (absinthe) lib/absinthe/phase/document/execution/resolution.ex:78: Absinthe.Phase.Document.Execution.Resolution.resolve_current/3
       (absinthe) lib/absinthe/pipeline.ex:204: Absinthe.Pipeline.run_phase/3
       (absinthe) lib/absinthe.ex:225: Absinthe.run/3
       test/graphs/tasks_test.exs:220: (test)
```